### PR TITLE
MAINT: delay xraydb import for import speed concerns

### DIFF
--- a/pcdscalc/be_lens_calcs.py
+++ b/pcdscalc/be_lens_calcs.py
@@ -7,7 +7,6 @@ from datetime import date
 from itertools import chain, product
 
 import numpy as np
-import xraydb as xdb
 
 from .constants import chemical_name_to_formula, density
 
@@ -319,6 +318,7 @@ def get_att_len(energy, material=None, density=None):
     >>> get_att_len(energy=8, material='Be')
     0.004810113254120656
     """
+    import xraydb as xdb
     material = material or MATERIAL
     density = density or xdb.atomic_density(material)
     try:
@@ -365,6 +365,7 @@ def get_delta(energy, material=None, density=None):
     >>> get_delta(energy=8, material='Au')
     4.728879989419882e-05
     """
+    import xraydb as xdb
     material = material or MATERIAL
     # xray_delta_beta returns (delta, beta, atlen), wehre delta : real part of
     # index of refraction, and takes x-ray energy in eV.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Delay the `xraydb` import until it is first used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Importing `xraydb` is slow and is not guaranteed to be used on execution of the progam.
Yes, the most useful calculations here all route through it, but consider the cases where:
1. we create lens devices in pcdsdevices for in/out control without doing calcs
2. we want to use the other calcs in here that don't need xraydb

If it was just item 1 I would want to do this in `pcdsdevices`, but since there are methods in here that don't intersect `xraydb` I think it's appropriate to do it in this module.

The speedup is about 0.7s for applications that don't use these methods, so it's probably worth it.

The reason we have a speedup is because `xraydb` imports `sqlalchemy` which has a slow import, among other things.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only
Tests still pass locally

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
