### PR TITLE
BLD: remove outdated pins, fix docs build

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,8 +23,7 @@ requirements:
   - python >=3.9
   - numpy
   - scipy
-  - sqlalchemy <2.0
-  - xraydb <4.5.0
+  - xraydb
 
 test:
   imports:

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,7 +2,7 @@
 docs-versions-menu
 numpydoc
 recommonmark
-sphinx
+sphinx<7
 sphinx-copybutton
 sphinx_rtd_theme
 sphinxcontrib-jquery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,5 @@ file = [ "requirements.txt",]
 [tool.setuptools.dynamic.optional-dependencies.test]
 file = "dev-requirements.txt"
 
-[tool.setuptools.dynamic.optional-dependencies.docs]
+[tool.setuptools.dynamic.optional-dependencies.doc]
 file = "docs-requirements.txt"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 scipy
-xraydb<4.5.0
-sqlalchemy<2.0
+xraydb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove outdated pins on sqlalchemy and xraydb
xraydb retained as a dependency, sqlalchemy isn't directly used here

fix minor issues with the docs build:
- typo in pyproject.toml that led to the CI not picking up the docs requirements
- avoid sphinx 7 incompatibility

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #21

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ci only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a, release notes later I guess?

<!--
## Screenshots (if appropriate):
-->
