### PR TITLE
BLD: pin numpy<2 for compatibility with xraylib

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - pip
   run:
   - python >=3.9
-  - numpy
+  - numpy <2.0
   - ophyd
   - periodictable
   - scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy <2
 ophyd
 periodictable
 scipy


### PR DESCRIPTION
## Description
pin numpy<2 , to ensure xraylib works

## Motivation and Context
numpy 2.0 changes a bunch of stuff, enough that xraylib needs a rebuild.  Rather than waiting on them to update, we'll pin this here

## How Has This Been Tested?
CI

## Where Has This Been Documented?
This PR