### PR TITLE
BLD: unpin numpy, xraylib now compatible

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - pip
   run:
   - python >=3.9
-  - numpy <2.0
+  - numpy
   - ophyd
   - periodictable
   - scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy <2
+numpy
 ophyd
 periodictable
 scipy


### PR DESCRIPTION
## Description
Unpins numpy, as of xraylib 4.1.5 we are compatible with npy2

## Motivation and Context
I dream of numpy 2.0

## How Has This Been Tested?
CI 

## Where Has This Been Documented?
This PR